### PR TITLE
File/New in Scratch now returns None

### DIFF
--- a/BrickPiScratch.py
+++ b/BrickPiScratch.py
@@ -132,8 +132,8 @@ while True:
     try:
         m = s.receive()
         
-        while m[0] == 'sensor-update' :
-            m = s.receive()
+        while m == None or m[0] == 'sensor-update':
+                m = s.receive()
 
         msg = m[1]
         if msg == 'SETUP' :


### PR DESCRIPTION
This was fixed for GoPiGo, but also needs to go in BrickPi.

The bug was introduced by a change of behaviour in nuScratch.  If the user does File/New in Scratch, it would crash the Communicator. 